### PR TITLE
feat: update markdown style and fix: duplicated slug

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -58,7 +58,7 @@ export default defineConfig({
             if (
               path.matchesGlob(relativePath, "src/content/contests/*/writeup")
             ) {
-              return file.data.astro?.frontmatter?.contest;
+              return relativePath;
             }
             return undefined;
           },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "astro-expressive-code": "^0.41.1",
     "astro-icon": "^1.1.5",
     "date-fns": "^4.1.0",
+    "github-slugger": "^2.0.0",
+    "hast-util-heading-rank": "^3.0.0",
+    "hast-util-to-string": "^3.0.1",
     "hastscript": "^9.0.1",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-katex": "^7.0.1",
@@ -40,8 +43,11 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@pandacss/dev": "^0.53.4",
+    "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
-    "lefthook": "^1.11.10"
+    "@types/node": "^22.15.11",
+    "lefthook": "^1.11.10",
+    "vfile": "^6.0.3"
   },
   "pnpm": {
     "executionEnv": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 0.9.4(prettier@3.2.5)(typescript@5.8.3)
       '@astrojs/mdx':
         specifier: ^4.2.4
-        version: 4.2.4(astro@5.7.2(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1))
+        version: 4.2.4(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1))
       '@astrojs/rss':
         specifier: ^4.0.11
         version: 4.0.11
@@ -34,16 +34,25 @@ importers:
         version: 1.2.3
       astro:
         specifier: ^5.7.2
-        version: 5.7.2(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
+        version: 5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
       astro-expressive-code:
         specifier: ^0.41.1
-        version: 0.41.1(astro@5.7.2(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1))
+        version: 0.41.1(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1))
       astro-icon:
         specifier: ^1.1.5
         version: 1.1.5
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
+      hast-util-heading-rank:
+        specifier: ^3.0.0
+        version: 3.0.0
+      hast-util-to-string:
+        specifier: ^3.0.1
+        version: 3.0.1
       hastscript:
         specifier: ^9.0.1
         version: 9.0.1
@@ -84,12 +93,21 @@ importers:
       '@pandacss/dev':
         specifier: ^0.53.4
         version: 0.53.4(typescript@5.8.3)
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
+      '@types/node':
+        specifier: ^22.15.11
+        version: 22.15.11
       lefthook:
         specifier: ^1.11.10
         version: 1.11.10
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -905,6 +923,9 @@ packages:
 
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+
+  '@types/node@22.15.11':
+    resolution: {integrity: sha512-rlyK0vuU7VLEYQfXuC7QTFxDvkb6tKhDI7wR4r6ZzM0k8BJd44W0jxo6xmUjqSs4AlYmiYfLJU2f0pAG/FtCRw==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -2769,6 +2790,9 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici@6.21.2:
     resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
     engines: {node: '>=18.17'}
@@ -3228,12 +3252,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.2.4(astro@5.7.2(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1))':
+  '@astrojs/mdx@4.2.4(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.1
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       acorn: 8.14.1
-      astro: 5.7.2(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
+      astro: 5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
       es-module-lexer: 1.6.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -4044,13 +4068,17 @@ snapshots:
 
   '@types/node@17.0.45': {}
 
+  '@types/node@22.15.11':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.15.11
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.15.11
       minipass: 4.2.8
 
   '@types/unist@2.0.11': {}
@@ -4059,7 +4087,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.15.11
     optional: true
 
   '@ungap/structured-clone@1.3.0': {}
@@ -4192,9 +4220,9 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.1(astro@5.7.2(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)):
+  astro-expressive-code@0.41.1(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)):
     dependencies:
-      astro: 5.7.2(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
+      astro: 5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
       rehype-expressive-code: 0.41.1
 
   astro-icon@1.1.5:
@@ -4206,7 +4234,7 @@ snapshots:
       - debug
       - supports-color
 
-  astro@5.7.2(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1):
+  astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1):
     dependencies:
       '@astrojs/compiler': 2.11.0
       '@astrojs/internal-helpers': 0.6.1
@@ -4259,8 +4287,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.15.0
       vfile: 6.0.3
-      vite: 6.3.0(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)
-      vitefu: 1.0.6(vite@6.3.0(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1))
+      vite: 6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)
+      vitefu: 1.0.6(vite@6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.1
@@ -6571,6 +6599,8 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
+  undici-types@6.21.0: {}
+
   undici@6.21.2: {}
 
   unicode-properties@1.4.1:
@@ -6680,7 +6710,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite@6.3.0(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1):
+  vite@6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.2
       fdir: 6.4.3(picomatch@4.0.2)
@@ -6689,14 +6719,15 @@ snapshots:
       rollup: 4.40.0
       tinyglobby: 0.2.12
     optionalDependencies:
+      '@types/node': 22.15.11
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.29.2
       yaml: 2.7.1
 
-  vitefu@1.0.6(vite@6.3.0(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)):
+  vitefu@1.0.6(vite@6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)):
     optionalDependencies:
-      vite: 6.3.0(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)
+      vite: 6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)
 
   volar-service-css@0.0.62(@volar/language-service@2.4.12):
     dependencies:

--- a/remark-image-extended/input.md
+++ b/remark-image-extended/input.md
@@ -2,10 +2,10 @@
 
 ![](https://example.com/image.png )
 
-![横600px {width:600px}](https://example.com/image.png)
+![横600px "width:600px"](https://example.com/image.png)
 
 
-![横500px縦200px {width:500px;height:200px}](https://example.com/image.png)
+![横500px縦200px "width:500px;height:200px"](https://example.com/image.png)
 
 
-![a {height:300px}](https://example.com/image.png)
+![a "height:300px"](https://example.com/image.png)

--- a/remark-image-extended/plugin.ts
+++ b/remark-image-extended/plugin.ts
@@ -3,7 +3,7 @@ import { visit } from "unist-util-visit";
 // 画像サイズ指定用remarkプラグイン
 export function remarkImageSizePlugin() {
   return (tree: Root) => {
-    const extendedImageRegex = /^(?<alt>.*) \{(?<style>.+=.+(;.+=.+)?)\}$/gm;
+    const extendedImageRegex = /^(?<alt>.*) "(?<style>.+=.+(;.+=.+)?)"$/gm;
     visit(tree, "image", (node) => {
       if (!node.alt) return;
 

--- a/src/content/contests/202505_tsukuctf2025/writeup/osint_curve.md
+++ b/src/content/contests/202505_tsukuctf2025/writeup/osint_curve.md
@@ -10,13 +10,13 @@ author: naotiki
 フラグはこの場所のWebサイトのドメインです。
 例: `TsukuCTF25{example.com}`
 
-![curve {width=30vmax;margin=auto}](./images/curve.jpg)
+![curve "width=30vmax;margin=auto"](./images/curve.jpg)
 
 Google Lensで調べると、どうやらスパイラルエスカレーターという珍しいエスカレーターらしい
 
 スパイラルエスカレーターで検索して画像を漁っていると・・・
 
-![google screenshot {width=30vmax;margin=auto}](./images/curve_2.png)
+![google screenshot "width=30vmax;margin=auto"](./images/curve_2.png)
 
 エスカレーターの警告表示(?)が似ている
 

--- a/src/pages/markdown-test.md
+++ b/src/pages/markdown-test.md
@@ -81,12 +81,26 @@ localhost:8080 ← `localhost:8080`と表示されるか
 
 # 画像の拡張記法
 ```md
-![m01nm01n {width=50%;margin=auto}](../assets/m01nm01n-logo.png)
+![m01nm01n "width=50%;margin=auto"](../assets/m01nm01n-logo.png)
 ```
-
-`<alt> {style1=value1;style2=value2}`のようにすると画像にスタイルを付与できる。
+`<alt> "style1=value1;style2=value2"`のようにすると画像にスタイルを付与できる。
 `:`(コロン)ではなく`=`なので注意
 
 
 
-![m01nm01n {width=50%;margin=auto}](../assets/m01nm01n-logo.png)
+![m01nm01n "width=50%;margin=auto"](../assets/m01nm01n-logo.png)
+
+
+
+
+- Kotlin
+  - Java
+  - Scala
+    - JavaScript
+- Go
+- Python
+- Rust
+
+1. capture
+2. the
+3. flag

--- a/src/panda-styles/index.ts
+++ b/src/panda-styles/index.ts
@@ -5,32 +5,25 @@ import { c } from "./utils";
 
 export const globalStyles = defineGlobalStyles({
   h1: {
-    fontSize: "5xl",
-    mt: "1rem",
-    lineHeight: 1.4,
+    fontSize: "4xl",
   },
   h2: {
-    fontSize: "4xl",
-    mt: "1rem",
-    lineHeight: 1.4,
+    fontSize: "3xl",
   },
   h3: {
-    fontSize: "3xl",
-    mt: "1rem",
-    lineHeight: 1.4,
+    fontSize: "2xl",
   },
   h4: {
-    fontSize: "2xl",
-    mt: "1rem",
-    lineHeight: 1.4,
+    fontSize: "xl",
   },
   h5: {
-    fontSize: "xl",
-    mt: "1rem",
-    lineHeight: 1.4,
+    fontSize: "lg",
   },
   h6: {
-    fontSize: "lg",
+    fontSize: "md",
+  },
+  "h1, h2, h3, h4, h5, h6": {
+    fontWeight: "bold",
     mt: "1rem",
     lineHeight: 1.4,
   },

--- a/src/panda-styles/markdown.ts
+++ b/src/panda-styles/markdown.ts
@@ -40,7 +40,38 @@ export const markdownStyle = {
     lineHeight: "1.5",
     color: "text",
   },
-
+  "ul, ol": {
+    listStylePosition: "inside",
+  },
+  // - [x]の回避
+  "ul:not(:has(input))": {
+    listStyleType: "disc",
+  },
+  ol: {
+    listStyleType: "decimal",
+  },
+  "ul ul, ol ul": {
+    listStyleType: "circle",
+    listStylePosition: "inside",
+    marginLeft: "5",
+  },
+  "ol ol, ul ol": {
+    listStyleType: "lower-latin",
+    listStylePosition: "inside",
+    marginLeft: "5",
+  },
+  ".expressive-code": {
+    margin: { base: "2", md: "5" },
+  },
+  img: {
+    margin: "2",
+  },
+  ":not(pre) > code": {
+    color: "red.500",
+    backgroundColor: "{colors.slate.500/20}",
+    padding: "1",
+    borderRadius: "0.5rem",
+  },
   // Note (Aside)
   /**
    * :::note_(warn|info|alert|success)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "paths": {
       "@/*": ["./src/*"],
       "@styles/*": ["./src/styled-system/*"]
-    }
+    },
+    "types": ["@types/hast", "@types/node"]
   }
 }


### PR DESCRIPTION
# Changes
- ul, ol のサポート
- Codeblock、Imageに余白を追加
- `inline code`に文字色・背景色と余白追加
- Headingの調整
- 画像の拡張記法がMDXと衝突するので修正
- Writeup Pageでslugが重複する問題を修正
