### PR TITLE
feat: Add interactive TUI tool for generating writeups

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "astro": "astro",
     "check": "biome check --write",
     "fmt": "biome format --write",
-    "lint": "biome lint --write"
+    "lint": "biome lint --write",
+    "new": "tsx scripts/new-writeup.ts",
+    "new:writeup": "tsx scripts/new-writeup.ts"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
@@ -43,17 +45,25 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@inquirer/prompts": "^7.5.3",
     "@pandacss/dev": "^0.53.4",
+    "@types/fs-extra": "^11.0.4",
     "@types/hast": "^3.0.4",
+    "@types/inquirer": "^9.0.8",
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.15.11",
+    "fs-extra": "^11.3.0",
+    "gray-matter": "^4.0.3",
+    "inquirer": "^12.6.3",
     "lefthook": "^1.11.10",
+    "tsx": "^4.19.4",
     "vfile": "^6.0.3"
   },
   "pnpm": {
     "executionEnv": {
       "nodeVersion": "22.15.0"
-    }
+    },
+    "onlyBuiltDependencies": ["@biomejs/biome", "esbuild", "lefthook", "sharp"]
   },
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 0.9.4(prettier@3.2.5)(typescript@5.8.3)
       '@astrojs/mdx':
         specifier: ^4.2.4
-        version: 4.2.4(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1))
+        version: 4.2.4(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
       '@astrojs/rss':
         specifier: ^4.0.11
         version: 4.0.11
@@ -34,10 +34,10 @@ importers:
         version: 1.2.3
       astro:
         specifier: ^5.7.2
-        version: 5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
+        version: 5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
       astro-expressive-code:
         specifier: ^0.41.1
-        version: 0.41.1(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1))
+        version: 0.41.1(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))
       astro-icon:
         specifier: ^1.1.5
         version: 1.1.5
@@ -93,21 +93,42 @@ importers:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
+      '@inquirer/prompts':
+        specifier: ^7.5.3
+        version: 7.5.3(@types/node@22.15.11)
       '@pandacss/dev':
         specifier: ^0.53.4
         version: 0.53.4(typescript@5.8.3)
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
+      '@types/inquirer':
+        specifier: ^9.0.8
+        version: 9.0.8
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
       '@types/node':
         specifier: ^22.15.11
         version: 22.15.11
+      fs-extra:
+        specifier: ^11.3.0
+        version: 11.3.0
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      inquirer:
+        specifier: ^12.6.3
+        version: 12.6.3(@types/node@22.15.11)
       lefthook:
         specifier: ^1.11.10
         version: 1.11.10
+      tsx:
+        specifier: ^4.19.4
+        version: 4.19.4
       vfile:
         specifier: ^6.0.3
         version: 6.0.3
@@ -687,6 +708,127 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/checkbox@4.1.8':
+    resolution: {integrity: sha512-d/QAsnwuHX2OPolxvYcgSj7A9DO9H6gVOy2DvBTx+P2LH2iRTo/RSGV3iwCzW024nP9hw98KIuDmdyhZQj1UQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.12':
+    resolution: {integrity: sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.1.13':
+    resolution: {integrity: sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.13':
+    resolution: {integrity: sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.15':
+    resolution: {integrity: sha512-4Y+pbr/U9Qcvf+N/goHzPEXiHH8680lM3Dr3Y9h9FFw4gHS+zVpbj8LfbKWIb/jayIB4aSO4pWiBTrBYWkvi5A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.12':
+    resolution: {integrity: sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.1.12':
+    resolution: {integrity: sha512-xJ6PFZpDjC+tC1P8ImGprgcsrzQRsUh9aH3IZixm1lAZFK49UGHxM3ltFfuInN2kPYNfyoPRh+tU4ftsjPLKqQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.15':
+    resolution: {integrity: sha512-xWg+iYfqdhRiM55MvqiTCleHzszpoigUpN5+t1OMcRkJrUrw7va3AzXaxvS+Ak7Gny0j2mFSTv2JJj8sMtbV2g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.15':
+    resolution: {integrity: sha512-75CT2p43DGEnfGTaqFpbDC2p2EEMrq0S+IRrf9iJvYreMy5mAWj087+mdKyLHapUEPLjN10mNvABpGbk8Wdraw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.5.3':
+    resolution: {integrity: sha512-8YL0WiV7J86hVAxrh3fE5mDCzcTDe1670unmJRz6ArDgN+DBK1a0+rbnNWp4DUB5rPMwqD5ZP6YHl9KK1mbZRg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.3':
+    resolution: {integrity: sha512-7XrV//6kwYumNDSsvJIPeAqa8+p7GJh7H5kRuxirct2cgOcSWwwNGoXDRgpNFbY/MG2vQ4ccIWCi8+IXXyFMZA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.0.15':
+    resolution: {integrity: sha512-YBMwPxYBrADqyvP4nNItpwkBnGGglAvCLVW8u4pRmmvOsHUtCAUIMbUrLX5B3tFL1/WsLGdQ2HNzkqswMs5Uaw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.2.3':
+    resolution: {integrity: sha512-OAGhXU0Cvh0PhLz9xTF/kx6g6x+sP+PcyTiLvCrewI99P3BBeexD+VbuwkNDvqGkk3y2h5ZiWLeRP7BFlhkUDg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.7':
+    resolution: {integrity: sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
@@ -906,8 +1048,17 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/fs-extra@11.0.4':
+    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/inquirer@9.0.8':
+    resolution: {integrity: sha512-CgPD5kFGWsb8HJ5K7rfWlifao87m4ph8uioU7OTncJevmE/VLIqAAjfQtko578JZg7/f69K4FgqYym3gNr7DeA==}
+
+  '@types/jsonfile@6.1.4':
+    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/katex@0.16.7':
     resolution: {integrity: sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==}
@@ -935,6 +1086,9 @@ packages:
 
   '@types/tar@6.1.13':
     resolution: {integrity: sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==}
+
+  '@types/through@0.0.33':
+    resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1009,6 +1163,10 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1031,6 +1189,9 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1156,6 +1317,9 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  chardet@0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
 
@@ -1178,6 +1342,10 @@ packages:
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1439,6 +1607,11 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
 
@@ -1472,8 +1645,16 @@ packages:
   exsolve@1.0.4:
     resolution: {integrity: sha512-xsZH6PXaER4XoV+NiT7JHp1bJodJVT+cxeSH1G0f0tlT0lJqYuHUP3bUx2HtfTDvOagMINYp8rsqusxud3RXhw==}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  external-editor@3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -1536,6 +1717,10 @@ packages:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
     engines: {node: '>=14.14'}
 
+  fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
+    engines: {node: '>=14.14'}
+
   fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
@@ -1571,6 +1756,9 @@ packages:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
 
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -1592,6 +1780,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
 
   h3@1.15.1:
     resolution: {integrity: sha512-+ORaOBttdUm1E2Uu/obAyCguiI7MbBvsLTndc3gyK3zU+SYLoZXlyCP9Xgy0gikkGufFLTZXCXD6+4BsufnmHA==}
@@ -1677,6 +1869,10 @@ packages:
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
 
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -1686,6 +1882,15 @@ packages:
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+
+  inquirer@12.6.3:
+    resolution: {integrity: sha512-eX9beYAjr1MqYsIjx1vAheXsRk1jbZRvHLcBu5nA9wX0rXR1IfCZLnVLp4Ym4mrhqmh7AuANwcdtgQ291fZDfQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -1706,6 +1911,10 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1750,6 +1959,10 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
+  js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -1769,6 +1982,10 @@ packages:
   katex@0.16.22:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
     hasBin: true
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -2247,6 +2464,10 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2306,6 +2527,10 @@ packages:
 
   oniguruma-to-es@4.2.0:
     resolution: {integrity: sha512-MDPs6KSOLS0tKQ7joqg44dRIRZUyotfTy0r+7oEEs6VwWWP0+E2PPDYWMFN0aqOjRyWHBYq7RfKw9GQk2S2z5g==}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
 
   outdent@0.8.0:
     resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
@@ -2585,6 +2810,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   restructure@3.0.2:
     resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
@@ -2609,14 +2837,25 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  run-async@3.0.0:
+    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
+    engines: {node: '>=0.12.0'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
 
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
@@ -2633,6 +2872,10 @@ packages:
 
   shiki@3.2.2:
     resolution: {integrity: sha512-0qWBkM2t/0NXPRcVgtLhtHv6Ak3Q5yI4K/ggMqcgLRKm4+pCs3namgZlhlat/7u2CuqNtlShNs9lENOG6n7UaQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -2664,6 +2907,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
@@ -2685,6 +2931,10 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
@@ -2717,6 +2967,10 @@ packages:
   tinyglobby@0.2.12:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
     engines: {node: '>=12.0.0'}
+
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2769,6 +3023,15 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.19.4:
+    resolution: {integrity: sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
 
   type-fest@4.40.0:
     resolution: {integrity: sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==}
@@ -3112,6 +3375,10 @@ packages:
     resolution: {integrity: sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==}
     engines: {node: '>=12.17'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -3164,6 +3431,10 @@ packages:
   yocto-spinner@0.2.1:
     resolution: {integrity: sha512-lHHxjh0bXaLgdJy3cNnVb/F9myx3CkhrvSOEVTkaUgNMXnYFa2xYPVhtGnqhh3jErY2gParBOHallCbc7NrlZQ==}
     engines: {node: '>=18.19'}
+
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
 
   yoctocolors@2.1.1:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
@@ -3261,12 +3532,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.2.4(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1))':
+  '@astrojs/mdx@4.2.4(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.1
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       acorn: 8.14.1
-      astro: 5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
+      astro: 5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
       es-module-lexer: 1.6.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -3719,6 +3990,122 @@ snapshots:
   '@img/sharp-win32-x64@0.34.1':
     optional: true
 
+  '@inquirer/checkbox@4.1.8(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/figures': 1.0.12
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/confirm@5.1.12(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/core@10.1.13(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/figures': 1.0.12
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/editor@4.2.13(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+      external-editor: 3.1.0
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/expand@4.0.15(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/figures@1.0.12': {}
+
+  '@inquirer/input@4.1.12(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/number@3.0.15(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/password@4.0.15(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+      ansi-escapes: 4.3.2
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/prompts@7.5.3(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/checkbox': 4.1.8(@types/node@22.15.11)
+      '@inquirer/confirm': 5.1.12(@types/node@22.15.11)
+      '@inquirer/editor': 4.2.13(@types/node@22.15.11)
+      '@inquirer/expand': 4.0.15(@types/node@22.15.11)
+      '@inquirer/input': 4.1.12(@types/node@22.15.11)
+      '@inquirer/number': 3.0.15(@types/node@22.15.11)
+      '@inquirer/password': 4.0.15(@types/node@22.15.11)
+      '@inquirer/rawlist': 4.1.3(@types/node@22.15.11)
+      '@inquirer/search': 3.0.15(@types/node@22.15.11)
+      '@inquirer/select': 4.2.3(@types/node@22.15.11)
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/rawlist@4.1.3(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/search@3.0.15(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/figures': 1.0.12
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/select@4.2.3(@types/node@22.15.11)':
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/figures': 1.0.12
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.15.11
+
+  '@inquirer/type@3.0.7(@types/node@22.15.11)':
+    optionalDependencies:
+      '@types/node': 22.15.11
+
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@mdx-js/mdx@3.1.0(acorn@8.14.1)':
@@ -4057,9 +4444,23 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/fs-extra@11.0.4':
+    dependencies:
+      '@types/jsonfile': 6.1.4
+      '@types/node': 22.15.11
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/inquirer@9.0.8':
+    dependencies:
+      '@types/through': 0.0.33
+      rxjs: 7.8.2
+
+  '@types/jsonfile@6.1.4':
+    dependencies:
+      '@types/node': 22.15.11
 
   '@types/katex@0.16.7': {}
 
@@ -4089,6 +4490,10 @@ snapshots:
     dependencies:
       '@types/node': 22.15.11
       minipass: 4.2.8
+
+  '@types/through@0.0.33':
+    dependencies:
+      '@types/node': 22.15.11
 
   '@types/unist@2.0.11': {}
 
@@ -4202,6 +4607,10 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
@@ -4219,6 +4628,10 @@ snapshots:
 
   arg@5.0.2: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
@@ -4229,9 +4642,9 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.1(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)):
+  astro-expressive-code@0.41.1(astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)):
     dependencies:
-      astro: 5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1)
+      astro: 5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
       rehype-expressive-code: 0.41.1
 
   astro-icon@1.1.5:
@@ -4243,7 +4656,7 @@ snapshots:
       - debug
       - supports-color
 
-  astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(typescript@5.8.3)(yaml@2.7.1):
+  astro@5.7.2(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1):
     dependencies:
       '@astrojs/compiler': 2.11.0
       '@astrojs/internal-helpers': 0.6.1
@@ -4296,8 +4709,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.15.0
       vfile: 6.0.3
-      vite: 6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)
-      vitefu: 1.0.6(vite@6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1))
+      vite: 6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.4)(yaml@2.7.1)
+      vitefu: 1.0.6(vite@6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.4)(yaml@2.7.1))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.1
@@ -4434,6 +4847,8 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  chardet@0.7.0: {}
+
   cheerio-select@2.1.0:
     dependencies:
       boolbase: 1.0.0
@@ -4466,6 +4881,8 @@ snapshots:
   ci-info@4.2.0: {}
 
   cli-boxes@3.0.0: {}
+
+  cli-width@4.1.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -4723,6 +5140,8 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  esprima@4.0.1: {}
+
   estree-util-attach-comments@3.0.0:
     dependencies:
       '@types/estree': 1.0.7
@@ -4769,7 +5188,17 @@ snapshots:
 
   exsolve@1.0.4: {}
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   extend@3.0.2: {}
+
+  external-editor@3.1.0:
+    dependencies:
+      chardet: 0.7.0
+      iconv-lite: 0.4.24
+      tmp: 0.0.33
 
   extract-zip@2.0.1:
     dependencies:
@@ -4842,6 +5271,12 @@ snapshots:
       jsonfile: 6.1.0
       universalify: 2.0.1
 
+  fs-extra@11.3.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
@@ -4879,6 +5314,10 @@ snapshots:
     dependencies:
       pump: 3.0.2
 
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
@@ -4894,6 +5333,13 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   h3@1.15.1:
     dependencies:
@@ -5103,6 +5549,10 @@ snapshots:
 
   http-cache-semantics@4.1.1: {}
 
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -5110,6 +5560,18 @@ snapshots:
   import-meta-resolve@4.1.0: {}
 
   inline-style-parser@0.2.4: {}
+
+  inquirer@12.6.3(@types/node@22.15.11):
+    dependencies:
+      '@inquirer/core': 10.1.13(@types/node@22.15.11)
+      '@inquirer/prompts': 7.5.3(@types/node@22.15.11)
+      '@inquirer/type': 3.0.7(@types/node@22.15.11)
+      ansi-escapes: 4.3.2
+      mute-stream: 2.0.0
+      run-async: 3.0.0
+      rxjs: 7.8.2
+    optionalDependencies:
+      '@types/node': 22.15.11
 
   iron-webcrypto@1.2.1: {}
 
@@ -5125,6 +5587,8 @@ snapshots:
   is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
+
+  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -5155,6 +5619,11 @@ snapshots:
   jiti@2.4.2:
     optional: true
 
+  js-yaml@3.14.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -5174,6 +5643,8 @@ snapshots:
   katex@0.16.22:
     dependencies:
       commander: 8.3.0
+
+  kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
 
@@ -5895,6 +6366,8 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
+  mute-stream@2.0.0: {}
+
   nanoid@3.3.11: {}
 
   neotraverse@0.6.18: {}
@@ -5945,6 +6418,8 @@ snapshots:
       oniguruma-parser: 0.11.1
       regex: 6.0.1
       regex-recursion: 6.0.2
+
+  os-tmpdir@1.0.2: {}
 
   outdent@0.8.0: {}
 
@@ -6334,6 +6809,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   restructure@3.0.2: {}
 
   retext-latin@4.0.0:
@@ -6389,13 +6866,24 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.40.0
       fsevents: 2.3.3
 
+  run-async@3.0.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safer-buffer@2.1.2: {}
 
   sax@1.4.1: {}
+
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
 
   semver@7.7.1: {}
 
@@ -6464,6 +6952,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  signal-exit@4.1.0: {}
+
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
@@ -6491,6 +6981,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  sprintf-js@1.0.3: {}
+
   stream-replace-string@2.0.0: {}
 
   string-width@4.2.3:
@@ -6517,6 +7009,8 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
+
+  strip-bom-string@1.0.0: {}
 
   strnum@1.1.2: {}
 
@@ -6564,6 +7058,10 @@ snapshots:
       fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -6597,6 +7095,15 @@ snapshots:
       typescript: 5.8.3
 
   tslib@2.8.1: {}
+
+  tsx@4.19.4:
+    dependencies:
+      esbuild: 0.25.2
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-fest@0.21.3: {}
 
   type-fest@4.40.0: {}
 
@@ -6727,7 +7234,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite@6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1):
+  vite@6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.2
       fdir: 6.4.3(picomatch@4.0.2)
@@ -6740,11 +7247,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.29.2
+      tsx: 4.19.4
       yaml: 2.7.1
 
-  vitefu@1.0.6(vite@6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)):
+  vitefu@1.0.6(vite@6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.4)(yaml@2.7.1)):
     optionalDependencies:
-      vite: 6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)
+      vite: 6.3.0(@types/node@22.15.11)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.4)(yaml@2.7.1)
 
   volar-service-css@0.0.62(@volar/language-service@2.4.12):
     dependencies:
@@ -6879,6 +7387,12 @@ snapshots:
 
   wordwrapjs@5.1.0: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -6940,6 +7454,8 @@ snapshots:
   yocto-spinner@0.2.1:
     dependencies:
       yoctocolors: 2.1.1
+
+  yoctocolors-cjs@2.1.2: {}
 
   yoctocolors@2.1.1: {}
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,93 @@
+# Writeup Generator
+
+新しいwriteupを対話形式で作成するTUIツールです。
+
+## 使用方法
+
+```bash
+pnpm new
+# または
+pnpm new:writeup
+```
+
+## 機能
+
+- 📚 既存のコンテストから選択、または新しいコンテストIDを入力
+- 🔍 **検索機能**: コンテストが多い場合（10個超）、タイトル・ID・日付で検索可能
+- 🔄 **自動構造変換**: 単体ファイルのコンテスト（.md/.mdx）を自動的にディレクトリ構造に変換
+- 🏷️ 定義済みカテゴリから選択、またはカスタムカテゴリを入力
+- 👥 既存のメンバーから選択、または新しい作者IDを入力
+- 🔍 **検索機能**: メンバーが多い場合（5人超）、名前・IDで検索可能
+- 📁 自動的にwriteupファイルとimagesディレクトリを作成
+- ✅ 作成前の確認プロンプト
+
+## 検索機能
+
+### コンテスト検索（10個超の場合）
+- タイトル、ID、日付で検索可能
+- 例: "tsuku"、"2025"、"ctf" などで絞り込み
+
+### メンバー検索（5人超の場合）
+- 名前、IDで検索可能
+- 例: "nao" で "naotiki" を検索
+- 部分一致で検索結果をリアルタイム表示
+
+## 自動構造変換
+
+ツールは単体ファイルとして存在するコンテスト（例：`202503_picoctf2025.mdx`）を自動的に適切なディレクトリ構造に変換します：
+
+```
+変換前:
+contests/202503_picoctf2025.mdx
+
+変換後:
+contests/202503_picoctf2025/
+├── index.mdx              # 元のコンテストファイル
+└── writeup/               # writeup用ディレクトリ
+    ├── {category}_{title}.md
+    └── images/
+```
+
+この変換は初回writeup作成時に自動的に実行されます。
+
+## 生成されるファイル
+
+```
+src/content/contests/{contest_id}/writeup/
+├── {category}_{title}.md  # writeupファイル
+└── images/                # 画像用ディレクトリ
+```
+
+## カテゴリ
+
+利用可能な定義済みカテゴリ:
+- welcome
+- pwn
+- rev
+- web
+- crypto
+- osint
+- forensics
+- web3
+- misc
+
+カスタムカテゴリも使用可能です（`+` プレフィックスで content.config.ts に記録されます）。
+
+## テンプレート
+
+生成されるwriteupテンプレート:
+
+```markdown
+---
+contest: {contest_id}
+title: {title}
+category: {category}
+author: {author}
+---
+
+### 問題
+
+
+### 解法
+
+```

--- a/scripts/new-writeup.ts
+++ b/scripts/new-writeup.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env tsx
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  confirmCreation,
+  promptWriteupDetails,
+} from "./writeup-generator/prompts";
+import {
+  createImagesDirectory,
+  createWriteupFile,
+} from "./writeup-generator/template";
+import type { WriteupTemplateData } from "./writeup-generator/types";
+import {
+  ensureWriteupDirectory,
+  generateFileName,
+  getExistingContests,
+  getExistingMembers,
+} from "./writeup-generator/utils";
+
+const CONTENT_DIR = join(process.cwd(), "src/content");
+
+async function main() {
+  try {
+    console.log("🔍 既存のコンテストとメンバーを読み込んでいます...\n");
+
+    // 既存のコンテストとメンバーを取得
+    const [contests, members] = await Promise.all([
+      getExistingContests(),
+      getExistingMembers(),
+    ]);
+
+    console.log(`📚 ${contests.length} 個のコンテストが見つかりました`);
+    console.log(`👥 ${members.length} 人のメンバーが見つかりました\n`);
+
+    // プロンプトでwriteupの詳細を入力
+    const answers = await promptWriteupDetails(contests, members);
+
+    // ファイルパスを生成（ディレクトリはまだ作成しない）
+    const fileName = generateFileName(answers.title, answers.category);
+    const writeupDir = join(
+      CONTENT_DIR,
+      "contests",
+      answers.contestId,
+      "writeup",
+    );
+    const filePath = join(writeupDir, fileName);
+
+    // ファイルが既に存在するかチェック
+    if (existsSync(filePath)) {
+      console.log(`❌ ファイルが既に存在します: ${filePath}`);
+      console.log("別のタイトルまたはカテゴリを使用してください。");
+      process.exit(1);
+    }
+
+    // 作成確認
+    const shouldCreate = await confirmCreation(filePath, answers);
+    if (!shouldCreate) {
+      console.log("❌ writeupの作成をキャンセルしました。");
+      process.exit(0);
+    }
+
+    // 確認後にwriteupディレクトリを確保（必要に応じてコンテスト構造を変換）
+    const actualWriteupDir = await ensureWriteupDirectory(answers.contestId);
+
+    // writeupファイルを作成
+    const templateData: WriteupTemplateData = {
+      ...answers,
+      filePath: join(actualWriteupDir, fileName),
+    };
+
+    await createWriteupFile(templateData);
+    await createImagesDirectory(actualWriteupDir);
+
+    console.log("\n🎉 writeupの作成が完了しました!");
+    console.log(
+      `📝 エディタでファイルを開いて編集を開始してください: ${templateData.filePath}`,
+    );
+  } catch (error) {
+    console.error("❌ エラーが発生しました:", error);
+    process.exit(1);
+  }
+}
+
+// スクリプトが直接実行された場合のみ main() を実行
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(console.error);
+}
+
+export { main };

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["**/*.ts", "../src/content.config.ts"]
+}

--- a/scripts/writeup-generator/prompts.ts
+++ b/scripts/writeup-generator/prompts.ts
@@ -1,0 +1,279 @@
+import { confirm, input, search, select } from "@inquirer/prompts";
+import { categories } from "./types";
+import type { WriteupPromptAnswers } from "./types";
+import type { ContestInfo, MemberInfo } from "./utils";
+
+/**
+ * writeup作成のためのプロンプトを実行
+ */
+export async function promptWriteupDetails(
+  contests: ContestInfo[],
+  members: MemberInfo[],
+): Promise<WriteupPromptAnswers> {
+  console.log("🚀 新しいwriteupを作成します\n");
+
+  // コンテスト選択
+  let contestId: string;
+  if (contests.length === 0) {
+    contestId = await input({
+      message: "コンテストID を入力してください:",
+      validate: (input) => {
+        if (!input.trim()) return "コンテストIDは必須です";
+        if (!/^[a-zA-Z0-9_-]+$/.test(input)) {
+          return "コンテストIDは英数字、ハイフン、アンダースコアのみ使用できます";
+        }
+        return true;
+      },
+    });
+  } else if (contests.length <= 10) {
+    // コンテストが少ない場合は従来の選択方式
+    const contestChoices = [
+      ...contests.map((contest) => ({
+        name: `${contest.title} (${contest.date})`,
+        value: contest.id,
+        description: contest.id,
+      })),
+      {
+        name: "📝 新しいコンテストを入力",
+        value: "__new__",
+        description: "新しいコンテストIDを入力します",
+      },
+    ];
+
+    const selectedContest = await select({
+      message: "コンテストを選択してください:",
+      choices: contestChoices,
+    });
+
+    if (selectedContest === "__new__") {
+      contestId = await input({
+        message: "新しいコンテストID を入力してください:",
+        validate: (input) => {
+          if (!input.trim()) return "コンテストIDは必須です";
+          if (!/^[a-zA-Z0-9_-]+$/.test(input)) {
+            return "コンテストIDは英数字、ハイフン、アンダースコアのみ使用できます";
+          }
+          return true;
+        },
+      });
+    } else {
+      contestId = selectedContest;
+    }
+  } else {
+    // コンテストが多い場合は検索機能付きの選択
+    const searchResult = await search({
+      message: "コンテストを検索してください (タイトルまたはIDで検索):",
+      source: async (input) => {
+        const searchTerm = input?.toLowerCase() || "";
+
+        const filteredContests = contests.filter(
+          (contest) =>
+            contest.title.toLowerCase().includes(searchTerm) ||
+            contest.id.toLowerCase().includes(searchTerm) ||
+            contest.date.toLowerCase().includes(searchTerm),
+        );
+
+        const choices = [
+          ...filteredContests.map((contest) => ({
+            name: `${contest.title} (${contest.date})`,
+            value: contest.id,
+            description: `ID: ${contest.id}`,
+          })),
+        ];
+
+        // 検索結果が少ない場合は「新しいコンテストを入力」オプションを追加
+        if (searchTerm && filteredContests.length === 0) {
+          choices.push({
+            name: `📝 新しいコンテストとして "${searchTerm}" を追加`,
+            value: searchTerm,
+            description: "新しいコンテストIDとして使用",
+          });
+        }
+
+        // 常に手動入力オプションを追加
+        choices.push({
+          name: "📝 新しいコンテストを手動入力",
+          value: "__new__",
+          description: "新しいコンテストIDを入力",
+        });
+
+        return choices;
+      },
+    });
+
+    if (searchResult === "__new__") {
+      contestId = await input({
+        message: "新しいコンテストID を入力してください:",
+        validate: (input) => {
+          if (!input.trim()) return "コンテストIDは必須です";
+          if (!/^[a-zA-Z0-9_-]+$/.test(input)) {
+            return "コンテストIDは英数字、ハイフン、アンダースコアのみ使用できます";
+          }
+          return true;
+        },
+      });
+    } else {
+      contestId = searchResult;
+    }
+  }
+
+  // タイトル入力
+  const title = await input({
+    message: "writeupのタイトルを入力してください:",
+    validate: (input) => {
+      if (!input.trim()) return "タイトルは必須です";
+      return true;
+    },
+  });
+
+  // カテゴリ選択
+  const categoryChoices = [
+    ...categories.map((cat) => ({
+      name: cat,
+      value: cat,
+    })),
+    {
+      name: "🔧 カスタムカテゴリを入力",
+      value: "__custom__",
+    },
+  ];
+
+  let category: string;
+  const selectedCategory = await select({
+    message: "カテゴリを選択してください:",
+    choices: categoryChoices,
+  });
+
+  if (selectedCategory === "__custom__") {
+    category = await input({
+      message: "カスタムカテゴリを入力してください:",
+      validate: (input) => {
+        if (!input.trim()) return "カテゴリは必須です";
+        return true;
+      },
+    });
+  } else {
+    category = selectedCategory;
+  }
+
+  // 作者選択
+  let author: string;
+  if (members.length === 0) {
+    author = await input({
+      message: "作者ID を入力してください:",
+      validate: (input) => {
+        if (!input.trim()) return "作者IDは必須です";
+        return true;
+      },
+    });
+  } else if (members.length <= 5) {
+    // メンバーが少ない場合は従来の選択方式
+    const authorChoices = [
+      ...members.map((member) => ({
+        name: `${member.name} (${member.id})`,
+        value: member.id,
+        description: member.id,
+      })),
+      {
+        name: "👤 新しい作者を入力",
+        value: "__new__",
+      },
+    ];
+
+    const selectedAuthor = await select({
+      message: "作者を選択してください:",
+      choices: authorChoices,
+    });
+
+    if (selectedAuthor === "__new__") {
+      author = await input({
+        message: "新しい作者ID を入力してください:",
+        validate: (input) => {
+          if (!input.trim()) return "作者IDは必須です";
+          return true;
+        },
+      });
+    } else {
+      author = selectedAuthor;
+    }
+  } else {
+    // メンバーが多い場合は検索機能付きの選択
+    const searchResult = await search({
+      message: "作者を検索してください (名前またはIDで検索):",
+      source: async (input) => {
+        const searchTerm = input?.toLowerCase() || "";
+
+        const filteredMembers = members.filter(
+          (member) =>
+            member.name.toLowerCase().includes(searchTerm) ||
+            member.id.toLowerCase().includes(searchTerm),
+        );
+
+        const choices = [
+          ...filteredMembers.map((member) => ({
+            name: `${member.name} (${member.id})`,
+            value: member.id,
+            description: `ID: ${member.id}`,
+          })),
+        ];
+
+        // 検索結果が少ない場合は「新しい作者を入力」オプションを追加
+        if (searchTerm && filteredMembers.length === 0) {
+          choices.push({
+            name: `👤 新しい作者として "${searchTerm}" を追加`,
+            value: searchTerm,
+            description: "新しい作者IDとして使用",
+          });
+        }
+
+        // 常に手動入力オプションを追加
+        choices.push({
+          name: "👤 新しい作者を手動入力",
+          value: "__new__",
+          description: "新しい作者IDを入力",
+        });
+
+        return choices;
+      },
+    });
+
+    if (searchResult === "__new__") {
+      author = await input({
+        message: "新しい作者ID を入力してください:",
+        validate: (input) => {
+          if (!input.trim()) return "作者IDは必須です";
+          return true;
+        },
+      });
+    } else {
+      author = searchResult;
+    }
+  }
+
+  return {
+    contestId,
+    title,
+    category,
+    author,
+  };
+}
+
+/**
+ * 作成確認プロンプト
+ */
+export async function confirmCreation(
+  filePath: string,
+  data: WriteupPromptAnswers,
+): Promise<boolean> {
+  console.log("\n📋 作成するwriteupの詳細:");
+  console.log(`   コンテスト: ${data.contestId}`);
+  console.log(`   タイトル: ${data.title}`);
+  console.log(`   カテゴリ: ${data.category}`);
+  console.log(`   作者: ${data.author}`);
+  console.log(`   ファイルパス: ${filePath}\n`);
+
+  return await confirm({
+    message: "このwriteupを作成しますか?",
+    default: true,
+  });
+}

--- a/scripts/writeup-generator/template.ts
+++ b/scripts/writeup-generator/template.ts
@@ -1,0 +1,54 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { WriteupTemplateData } from "./types";
+
+/**
+ * writeupのMarkdownテンプレートを生成
+ */
+export function generateWriteupTemplate(data: WriteupTemplateData): string {
+  return `---
+contest: ${data.contestId}
+title: ${data.title}
+category: ${data.category}
+author: ${data.author}
+---
+
+### 問題
+
+
+### 解法
+
+`;
+}
+
+/**
+ * writeupファイルを作成
+ */
+export async function createWriteupFile(
+  data: WriteupTemplateData,
+): Promise<void> {
+  const template = generateWriteupTemplate(data);
+
+  // ディレクトリが存在しない場合は作成
+  const dir = dirname(data.filePath);
+  await mkdir(dir, { recursive: true });
+
+  // ファイルを作成
+  await writeFile(data.filePath, template, "utf-8");
+
+  console.log(`✅ Writeupファイルを作成しました: ${data.filePath}`);
+}
+
+/**
+ * imagesディレクトリを作成（.gitkeepファイル付き）
+ */
+export async function createImagesDirectory(writeupDir: string): Promise<void> {
+  const imagesDir = join(writeupDir, "images");
+  await mkdir(imagesDir, { recursive: true });
+
+  // .gitkeepファイルを作成
+  const gitkeepPath = join(imagesDir, ".gitkeep");
+  await writeFile(gitkeepPath, "", "utf-8");
+
+  console.log(`✅ imagesディレクトリを作成しました: ${imagesDir}`);
+}

--- a/scripts/writeup-generator/types.ts
+++ b/scripts/writeup-generator/types.ts
@@ -1,0 +1,34 @@
+// Content configと同期したカテゴリ定義
+// src/content.config.tsの categories 配列と一致させる必要があります
+
+// カテゴリの定数配列（content.config.tsと同期）
+export const categories = [
+  "welcome",
+  "pwn",
+  "rev",
+  "web",
+  "crypto",
+  "osint",
+  "forensics",
+  "web3",
+  "misc",
+] as const;
+
+export type Category = (typeof categories)[number];
+
+// プロンプト用の選択肢型
+export interface WriteupPromptAnswers {
+  contestId: string;
+  title: string;
+  category: Category | string; // カスタムカテゴリも許可
+  author: string;
+}
+
+// テンプレート生成用の情報
+export interface WriteupTemplateData {
+  contestId: string;
+  title: string;
+  category: string;
+  author: string;
+  filePath: string;
+}

--- a/scripts/writeup-generator/utils.ts
+++ b/scripts/writeup-generator/utils.ts
@@ -1,0 +1,188 @@
+import { mkdir, readFile, readdir, rename, stat } from "node:fs/promises";
+import { join } from "node:path";
+// @ts-ignore
+import matter from "gray-matter";
+
+const CONTENT_DIR = join(process.cwd(), "src/content");
+
+export interface ContestInfo {
+  id: string;
+  title: string;
+  date: string;
+}
+
+export interface MemberInfo {
+  id: string;
+  name: string;
+}
+
+/**
+ * 既存のコンテストを取得
+ */
+export async function getExistingContests(): Promise<ContestInfo[]> {
+  try {
+    const contestsDir = join(CONTENT_DIR, "contests");
+    const entries = await readdir(contestsDir);
+    const contests: ContestInfo[] = [];
+
+    for (const entry of entries) {
+      const fullPath = join(contestsDir, entry);
+      const isDirectory = (await stat(fullPath)).isDirectory();
+
+      if (isDirectory) {
+        // ディレクトリの場合、index.mdを探す
+        const indexPath = join(fullPath, "index.md");
+        try {
+          const content = await readFile(indexPath, "utf-8");
+          const { data } = matter(content);
+          contests.push({
+            id: entry,
+            title: data.title || entry,
+            date: data.startDate
+              ? new Date(data.startDate).toLocaleDateString()
+              : "不明",
+          });
+        } catch {
+          // index.mdが見つからない場合はスキップ
+        }
+      } else if (entry.endsWith(".md") || entry.endsWith(".mdx")) {
+        // ファイルの場合
+        const content = await readFile(fullPath, "utf-8");
+        const { data } = matter(content);
+        const id = entry.replace(/\.(md|mdx)$/, "");
+        contests.push({
+          id,
+          title: data.title || id,
+          date: data.startDate
+            ? new Date(data.startDate).toLocaleDateString()
+            : "不明",
+        });
+      }
+    }
+
+    return contests.sort((a, b) => a.title.localeCompare(b.title));
+  } catch (error) {
+    console.warn("コンテストの取得に失敗しました:", error);
+    return [];
+  }
+}
+
+/**
+ * 既存のメンバーを取得
+ */
+export async function getExistingMembers(): Promise<MemberInfo[]> {
+  try {
+    const membersDir = join(CONTENT_DIR, "members");
+    const files = await readdir(membersDir);
+    const members: MemberInfo[] = [];
+
+    for (const file of files) {
+      if (file.endsWith(".md") || file.endsWith(".mdx")) {
+        const filePath = join(membersDir, file);
+        const content = await readFile(filePath, "utf-8");
+        const { data } = matter(content);
+        const id = file.replace(/\.(md|mdx)$/, "");
+
+        members.push({
+          id,
+          name: data.name || id,
+        });
+      }
+    }
+
+    return members.sort((a, b) => a.name.localeCompare(b.name));
+  } catch (error) {
+    console.warn("メンバーの取得に失敗しました:", error);
+    return [];
+  }
+}
+
+/**
+ * コンテストIDのバリデーション
+ */
+export function validateContestId(contestId: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(contestId);
+}
+
+/**
+ * ファイル名からコンテストIDを生成
+ */
+export function generateFileName(title: string, category: string): string {
+  const cleanTitle = title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-_]/g, "")
+    .replace(/\s+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+
+  return `${category}_${cleanTitle}.md`;
+}
+
+/**
+ * 単体ファイルのコンテストをディレクトリ構造に変換
+ */
+export async function convertContestToDirectory(
+  contestId: string,
+): Promise<void> {
+  const contestsDir = join(CONTENT_DIR, "contests");
+  const contestFile = join(contestsDir, `${contestId}.md`);
+  const contestMdxFile = join(contestsDir, `${contestId}.mdx`);
+
+  let sourceFile: string | null = null;
+  let fileExtension = "";
+
+  // .md または .mdx ファイルが存在するかチェック
+  try {
+    await stat(contestFile);
+    sourceFile = contestFile;
+    fileExtension = ".md";
+  } catch {
+    try {
+      await stat(contestMdxFile);
+      sourceFile = contestMdxFile;
+      fileExtension = ".mdx";
+    } catch {
+      // ファイルが存在しない場合は何もしない
+      return;
+    }
+  }
+
+  if (!sourceFile) return;
+
+  console.log(
+    `📁 コンテスト "${contestId}" をディレクトリ構造に変換しています...`,
+  );
+
+  // 新しいディレクトリを作成
+  const contestDir = join(contestsDir, contestId);
+  await mkdir(contestDir, { recursive: true });
+
+  // ファイルを移動してindex.mdに変更
+  const newIndexFile = join(contestDir, `index${fileExtension}`);
+  await rename(sourceFile, newIndexFile);
+
+  console.log(`✅ ${sourceFile} -> ${newIndexFile} に移動しました`);
+}
+
+/**
+ * writeupディレクトリが存在するかチェックし、必要に応じて作成
+ */
+export async function ensureWriteupDirectory(
+  contestId: string,
+): Promise<string> {
+  const contestsDir = join(CONTENT_DIR, "contests");
+  const contestDir = join(contestsDir, contestId);
+  const writeupDir = join(contestDir, "writeup");
+
+  // コンテストディレクトリが存在しない場合、単体ファイルから変換を試行
+  try {
+    await stat(contestDir);
+  } catch {
+    await convertContestToDirectory(contestId);
+  }
+
+  // writeupディレクトリを作成
+  await mkdir(writeupDir, { recursive: true });
+
+  return writeupDir;
+}


### PR DESCRIPTION
- Implemented a new script for creating writeups interactively with prompts for contest selection, title, category, and author.
- Added functionality to search existing contests and members, and to create a structured directory for writeups.
- Introduced automatic conversion of single contest files into a directory structure.
- Created a markdown template for writeups with placeholders for contest details.
- Enhanced user experience with confirmation prompts before creating files.
- Included utility functions for managing contests and members, and for file operations.
- Documented usage and features in a new README.md file.