### PR TITLE
Add member template creation

### DIFF
--- a/scripts/new-writeup.ts
+++ b/scripts/new-writeup.ts
@@ -8,9 +8,13 @@ import {
 } from "./writeup-generator/prompts";
 import {
   createImagesDirectory,
+  createMemberFile,
   createWriteupFile,
 } from "./writeup-generator/template";
-import type { WriteupTemplateData } from "./writeup-generator/types";
+import type {
+  MemberTemplateData,
+  WriteupTemplateData,
+} from "./writeup-generator/types";
 import {
   ensureWriteupDirectory,
   generateFileName,
@@ -58,6 +62,20 @@ async function main() {
     if (!shouldCreate) {
       console.log("❌ writeupの作成をキャンセルしました。");
       process.exit(0);
+    }
+
+    const isNewAuthor = !members.some((m) => m.id === answers.author);
+    const memberFilePath = join(
+      CONTENT_DIR,
+      "members",
+      `${answers.author}.mdx`,
+    );
+    if (isNewAuthor && !existsSync(memberFilePath)) {
+      const memberData: MemberTemplateData = {
+        id: answers.author,
+        filePath: memberFilePath,
+      };
+      await createMemberFile(memberData);
     }
 
     // 確認後にwriteupディレクトリを確保（必要に応じてコンテスト構造を変換）

--- a/scripts/writeup-generator/template.ts
+++ b/scripts/writeup-generator/template.ts
@@ -1,6 +1,10 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import type { WriteupTemplateData } from "./types";
+import type { MemberTemplateData, WriteupTemplateData } from "./types";
+import {
+  validateMemberFrontmatter,
+  validateWriteupFrontmatter,
+} from "./validation";
 
 /**
  * writeupのMarkdownテンプレートを生成
@@ -36,6 +40,8 @@ export async function createWriteupFile(
   // ファイルを作成
   await writeFile(data.filePath, template, "utf-8");
 
+  await validateWriteupFrontmatter(data.filePath);
+
   console.log(`✅ Writeupファイルを作成しました: ${data.filePath}`);
 }
 
@@ -51,4 +57,26 @@ export async function createImagesDirectory(writeupDir: string): Promise<void> {
   await writeFile(gitkeepPath, "", "utf-8");
 
   console.log(`✅ imagesディレクトリを作成しました: ${imagesDir}`);
+}
+
+export function generateMemberTemplate(id: string): string {
+  return `---
+name: ${id}
+---
+`;
+}
+
+export async function createMemberFile(
+  data: MemberTemplateData,
+): Promise<void> {
+  const template = generateMemberTemplate(data.id);
+
+  const dir = dirname(data.filePath);
+  await mkdir(dir, { recursive: true });
+
+  await writeFile(data.filePath, template, "utf-8");
+
+  await validateMemberFrontmatter(data.filePath);
+
+  console.log(`✅ Memberファイルを作成しました: ${data.filePath}`);
 }

--- a/scripts/writeup-generator/types.ts
+++ b/scripts/writeup-generator/types.ts
@@ -1,18 +1,7 @@
 // Content configと同期したカテゴリ定義
 // src/content.config.tsの categories 配列と一致させる必要があります
 
-// カテゴリの定数配列（content.config.tsと同期）
-export const categories = [
-  "welcome",
-  "pwn",
-  "rev",
-  "web",
-  "crypto",
-  "osint",
-  "forensics",
-  "web3",
-  "misc",
-] as const;
+export { categories } from "../../src/content/schemas";
 
 export type Category = (typeof categories)[number];
 
@@ -30,5 +19,10 @@ export interface WriteupTemplateData {
   title: string;
   category: string;
   author: string;
+  filePath: string;
+}
+
+export interface MemberTemplateData {
+  id: string;
   filePath: string;
 }

--- a/scripts/writeup-generator/utils.ts
+++ b/scripts/writeup-generator/utils.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, stat, glob } from "node:fs/promises";
+import { glob, mkdir, readFile, rename, stat } from "node:fs/promises";
 import { join } from "node:path";
 // @ts-ignore
 import matter from "gray-matter";
@@ -99,7 +99,7 @@ export function validateContestId(contestId: string): boolean {
 export function generateFileName(title: string, category: string): string {
   const cleanTitle = title
     .toLowerCase()
-    .replace(/[^a-z0-9\s-_]/g, "")
+    .replace(/[^a-z0-9\s_-]/g, "")
     .replace(/\s+/g, "_")
     .replace(/_+/g, "_")
     .replace(/^_|_$/g, "");
@@ -117,7 +117,9 @@ export async function convertContestToDirectory(
   let sourceFile: string | null = null;
   let fileExtension = "";
 
-  for await (const file of glob(`${contestId}.{md,mdx}`, { cwd: contestsDir })) {
+  for await (const file of glob(`${contestId}.{md,mdx}`, {
+    cwd: contestsDir,
+  })) {
     sourceFile = join(contestsDir, file);
     fileExtension = file.endsWith(".mdx") ? ".mdx" : ".md";
     break;

--- a/scripts/writeup-generator/validation.ts
+++ b/scripts/writeup-generator/validation.ts
@@ -1,0 +1,22 @@
+import { readFile } from "node:fs/promises";
+import matter from "gray-matter";
+import {
+  memberFrontmatterSchema,
+  writeupFrontmatterSchema,
+} from "../../src/content/schemas";
+
+export async function validateWriteupFrontmatter(
+  filePath: string,
+): Promise<void> {
+  const content = await readFile(filePath, "utf-8");
+  const { data } = matter(content);
+  writeupFrontmatterSchema.parse(data);
+}
+
+export async function validateMemberFrontmatter(
+  filePath: string,
+): Promise<void> {
+  const content = await readFile(filePath, "utf-8");
+  const { data } = matter(content);
+  memberFrontmatterSchema.parse(data);
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,11 @@
 import { defineCollection, reference, z } from "astro:content";
 import { glob } from "astro/loaders";
+import {
+  categories,
+  categoriesSchema,
+  memberFrontmatterSchema,
+  writeupFrontmatterSchema,
+} from "./content/schemas";
 const blog = defineCollection({
   // Load Markdown and MDX files in the `src/content/blog/` directory.
   loader: glob({ base: "./src/content/blog", pattern: "**/*.{md,mdx}" }),
@@ -60,38 +66,16 @@ const contests = defineCollection({
     }),
 });
 
-//表記揺れ防止
-const categories = [
-  "welcome",
-  "pwn",
-  "rev",
-  "web",
-  "crypto",
-  "osint",
-  "forensics",
-  "web3",
-  "misc",
-] as const;
-const categoriesSchema = z.enum(categories);
+// 表記揺れ防止
 
 const writeup = defineCollection({
   loader: glob({
     base: "./src/content/contests",
     pattern: "*/writeup/*.{md,mdx}",
   }),
-  schema: (c) =>
-    z.object({
+  schema: () =>
+    writeupFrontmatterSchema.extend({
       contest: reference("contests"),
-      title: z.string(),
-      // + をつけると、任意のカテゴリ名(非推奨)
-      category: categoriesSchema
-        .or(z.string().startsWith("+"))
-        .transform((t) => {
-          if (t.startsWith("+")) {
-            return t.slice(1);
-          }
-          return t;
-        }),
       author: reference("member"),
     }),
 });
@@ -99,19 +83,8 @@ const writeup = defineCollection({
 const member = defineCollection({
   loader: glob({ base: "./src/content/members", pattern: "*.{md,mdx}" }),
   schema: ({ image }) =>
-    z.object({
-      // 名前 (表示用)
-      name: z.string(),
-      // 本名 (opt)
-      realName: z.string().optional(),
-      // 自己紹介 (opt)
-      description: z.string().optional(),
-      // スキル (opt)
-      skills: z.string().array().optional(),
-      image: image(),
-      x_twitter: z.string().url().optional(),
-      github: z.string().url().optional(),
-      website: z.string().url().optional(),
+    memberFrontmatterSchema.extend({
+      image: image().optional(),
     }),
 });
 

--- a/src/content/schemas.ts
+++ b/src/content/schemas.ts
@@ -1,0 +1,35 @@
+import { z } from "astro:content";
+
+export const categories = [
+  "welcome",
+  "pwn",
+  "rev",
+  "web",
+  "crypto",
+  "osint",
+  "forensics",
+  "web3",
+  "misc",
+] as const;
+
+export const categoriesSchema = z.enum(categories);
+
+export const writeupFrontmatterSchema = z.object({
+  contest: z.string(),
+  title: z.string(),
+  category: categoriesSchema
+    .or(z.string().startsWith("+"))
+    .transform((t) => (t.startsWith("+") ? t.slice(1) : t)),
+  author: z.string(),
+});
+
+export const memberFrontmatterSchema = z.object({
+  name: z.string(),
+  realName: z.string().optional(),
+  description: z.string().optional(),
+  skills: z.array(z.string()).optional(),
+  image: z.string().optional(),
+  x_twitter: z.string().url().optional(),
+  github: z.string().url().optional(),
+  website: z.string().url().optional(),
+});


### PR DESCRIPTION
## Summary
- when entering a new author, automatically scaffold a member file
- allow blank `image` fields and validate frontmatter
- centralize content schemas for validation and config

## Testing
- `pnpm install`
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_684c2fb95910832bad3b48c87385a8aa